### PR TITLE
Add Dockerfile for native Quarkus build support

### DIFF
--- a/src/main/docker/Dockerfile.builder
+++ b/src/main/docker/Dockerfile.builder
@@ -1,0 +1,8 @@
+# docker build -f src/main/docker/Dockerfile.builder -t quarkus-native-builder .
+#  mvn package -Dnative -Dquarkus.native.container-build=true -Dquarkus.native.builder-image=quarkus-native-builder -Dquarkus.native.builder-image.pull=never
+
+FROM quay.io/quarkus/ubi9-quarkus-mandrel-builder-image:jdk-23
+
+USER root
+RUN microdnf install -y libXxf86vm pango mesa-libGL && microdnf clean all
+USER 1000


### PR DESCRIPTION
Introduce a builder Dockerfile to streamline native Quarkus builds. It includes necessary dependencies and configuration for container-based native image creation using Mandrel.